### PR TITLE
Namespace refactor pt3

### DIFF
--- a/analyzer/analyzer.cpp
+++ b/analyzer/analyzer.cpp
@@ -48,7 +48,7 @@ void Analyzer::visit(syntax::ast::ASTProgram* program){
 }
 
 void Analyzer::visit(syntax::ast::ASTIncludeDir* includeDir){
-    if(!std::filesystem::exists(Preprocessing::Libs::generateLibSourcePath(includeDir->getLibName()))){
+    if(!std::filesystem::exists(preprocessing::generateLibSourcePath(includeDir->getLibName()))){
         const auto& token{ includeDir->getToken() };
         reportError(
             token, 

--- a/code-generator/asm-generator/asm_instruction_generator.hpp
+++ b/code-generator/asm-generator/asm_instruction_generator.hpp
@@ -8,10 +8,10 @@
 #include <cstddef>
 
 /** 
- * @namespace AsmGenerator::Instruction
- * @brief Module for generating the x86-64 asm instructions
+ * @namespace assembly
+ * @brief Module for generating the x86-64 assembly
 */
-namespace AsmGenerator::Instruction {
+namespace assembly {
     /// size of the register in bytes
     constexpr size_t regSize{8};
 

--- a/code-generator/asm-generator/source/asm_instruction_generator.cpp
+++ b/code-generator/asm-generator/source/asm_instruction_generator.cpp
@@ -2,14 +2,14 @@
 
 #include <format>
 
-std::atomic<size_t> AsmGenerator::Instruction::labelNum{0};
+std::atomic<size_t> assembly::labelNum{0};
 
-size_t AsmGenerator::Instruction::getNextLabelNum() noexcept {
+size_t assembly::getNextLabelNum() noexcept {
     return labelNum.fetch_add(1, std::memory_order_relaxed);
 }
 
 // start of an asm file
-const std::string AsmGenerator::Instruction::genStart(){
+const std::string assembly::genStart(){
     return std::format(
         "{}{}{}{}", 
         ".global _start\n", 
@@ -19,7 +19,7 @@ const std::string AsmGenerator::Instruction::genStart(){
     );
 }
 
-void AsmGenerator::Instruction::genMov(
+void assembly::genMov(
     std::vector<std::string>& asmCode, 
     std::string_view src, 
     std::string_view dest, 
@@ -28,7 +28,7 @@ void AsmGenerator::Instruction::genMov(
     asmCode.push_back(std::format("\tmov{} {}, {}\n", ext, src, dest));
 }
 
-void AsmGenerator::Instruction::genSet(
+void assembly::genSet(
     std::vector<std::string>& asmCode, 
     std::string_view dest, 
     std::string_view ext
@@ -36,7 +36,7 @@ void AsmGenerator::Instruction::genSet(
     asmCode.push_back(std::format("\tset{} {}\n", ext, dest));
 }
 
-void AsmGenerator::Instruction::genSetcc(
+void assembly::genSetcc(
     std::vector<std::string>& asmCode, 
     std::string_view setcc, 
     std::string_view dest
@@ -44,7 +44,7 @@ void AsmGenerator::Instruction::genSetcc(
     asmCode.push_back(std::format("\t{} {}\n", setcc, dest));
 }
 
-void AsmGenerator::Instruction::genTest(
+void assembly::genTest(
     std::vector<std::string>& asmCode, 
     std::string_view op, 
     std::string_view ext
@@ -52,7 +52,7 @@ void AsmGenerator::Instruction::genTest(
     asmCode.push_back(std::format("\ttest{} {}, {}\n", ext, op, op));
 }
 
-void AsmGenerator::Instruction::genTest(
+void assembly::genTest(
     std::vector<std::string> &asmCode, 
     std::string_view lOp, 
     std::string_view rOp, 
@@ -61,7 +61,7 @@ void AsmGenerator::Instruction::genTest(
     asmCode.push_back(std::format("\ttest{} {}, {}\n", ext, lOp, rOp));
 }
 
-void AsmGenerator::Instruction::genCmp(
+void assembly::genCmp(
     std::vector<std::string>& asmCode, 
     std::string_view lOp, 
     std::string_view rOp
@@ -69,7 +69,7 @@ void AsmGenerator::Instruction::genCmp(
     asmCode.push_back(std::format("\tcmp {}, {}\n", lOp, rOp));
 }
 
-void AsmGenerator::Instruction::genOperation(
+void assembly::genOperation(
     std::vector<std::string>& asmCode, 
     std::string_view operation, 
     std::string_view src, 
@@ -78,7 +78,7 @@ void AsmGenerator::Instruction::genOperation(
     asmCode.push_back(std::format("\t{} {}, {}\n", operation, src, dest));
 }
 
-void AsmGenerator::Instruction::genOperation(
+void assembly::genOperation(
     std::vector<std::string>& asmCode, 
     std::string_view operation, 
     std::string_view dest
@@ -86,25 +86,25 @@ void AsmGenerator::Instruction::genOperation(
     asmCode.push_back(std::format("\t{} {}\n", operation, dest));
 }
 
-void AsmGenerator::Instruction::genLabel(
+void assembly::genLabel(
     std::vector<std::string>& asmCode, 
     std::string_view label
 ){
     asmCode.push_back(std::format("{}:\n", label));
 }
 
-void AsmGenerator::Instruction::genRet(std::vector<std::string>& asmCode){
+void assembly::genRet(std::vector<std::string>& asmCode){
     asmCode.push_back("\tret\n");
 }
 
-void AsmGenerator::Instruction::genJmp(
+void assembly::genJmp(
     std::vector<std::string>& asmCode, 
     std::string_view label
 ){
     asmCode.push_back(std::format("\tjmp {}\n", label));
 }
 
-void AsmGenerator::Instruction::genJcc(
+void assembly::genJcc(
     std::vector<std::string>& asmCode, 
     std::string_view jcc, 
     std::string_view label
@@ -112,38 +112,38 @@ void AsmGenerator::Instruction::genJcc(
     asmCode.push_back(std::format("\t{} {}\n", jcc, label));
 }
 
-void AsmGenerator::Instruction::genCall(
+void assembly::genCall(
     std::vector<std::string>& asmCode, 
     std::string_view func
 ){
     asmCode.push_back(std::format("\tcall {}\n", func));
 }
 
-void AsmGenerator::Instruction::genPush(
+void assembly::genPush(
     std::vector<std::string>& asmCode, 
     std::string_view src
 ){
     asmCode.push_back(std::format("\tpush {}\n", src));
 }
 
-void AsmGenerator::Instruction::genPop(
+void assembly::genPop(
     std::vector<std::string>& asmCode, 
     std::string_view dest
 ){
     asmCode.push_back(std::format("\tpop {}\n", dest));
 }
 
-void AsmGenerator::Instruction::genFuncPrologue(std::vector<std::string>& asmCode){
+void assembly::genFuncPrologue(std::vector<std::string>& asmCode){
     genPush(asmCode, "%rbp");
     genMov(asmCode, "%rsp", "%rbp");
 }
 
-void AsmGenerator::Instruction::genFuncEpilogue(std::vector<std::string>& asmCode){
+void assembly::genFuncEpilogue(std::vector<std::string>& asmCode){
     genMov(asmCode, "%rbp", "%rsp");
     genPop(asmCode, "%rbp");
 }
 
-void AsmGenerator::Instruction::genExit(std::vector<std::string>& asmCode){
+void assembly::genExit(std::vector<std::string>& asmCode){
     asmCode.push_back(std::format(
         "{}{}{}", 
         "\tmov %rax, %rdi\n", 
@@ -152,6 +152,6 @@ void AsmGenerator::Instruction::genExit(std::vector<std::string>& asmCode){
     ); // return value in %rdi
 }
 
-void AsmGenerator::Instruction::genNewLine(std::vector<std::string>& asmCode){
+void assembly::genNewLine(std::vector<std::string>& asmCode){
     asmCode.push_back("\n");
 }

--- a/code-generator/code-generator/source/code_generator.cpp
+++ b/code-generator/code-generator/source/code_generator.cpp
@@ -43,7 +43,7 @@ void CodeGenerator::writeCode(const ir::IRProgram* program){
     }
 
     // start of asm code
-    file << AsmGenerator::Instruction::genStart();
+    file << assembly::genStart();
 
     for(const auto& function : program->getFunctions()){
         for(const auto& instruction : asmCode[function->getFunctionName()]){

--- a/code-generator/code-generator/source/expression_code_generator.cpp
+++ b/code-generator/code-generator/source/expression_code_generator.cpp
@@ -78,7 +78,7 @@ void ExpressionCodeGenerator::generateBinaryExpr(const ir::IRBinaryExpr* binaryE
     }
     if(exprCtx == ExprContext::VALUE){
         if(ctx.gpFreeRegPos >= gpRegisters.size()){
-            AsmGenerator::Instruction::genPush(ctx.asmCode, operands.rightOperand);
+            assembly::genPush(ctx.asmCode, operands.rightOperand);
         }
         ctx.takeGpReg();
     }
@@ -90,7 +90,7 @@ std::string ExpressionCodeGenerator::getUnaryOperand(std::string_view fallbackOp
     ctx.freeGpReg();
     if(ctx.gpFreeRegPos >= gpRegisters.size()){
         operand = fallbackOperand;
-        AsmGenerator::Instruction::genPop(ctx.asmCode, fallbackOperand);
+        assembly::genPop(ctx.asmCode, fallbackOperand);
     }
     else{
         operand = gpRegisters.at(ctx.gpFreeRegPos);
@@ -109,31 +109,31 @@ BinaryOperands ExpressionCodeGenerator::getBinaryOperands(){
 void ExpressionCodeGenerator::generateMultiplicativeExpr(const ir::IRBinaryExpr* binaryExpr, BinaryOperands operands){
     ir::IRNodeType nodeType{ binaryExpr->getNodeType() };
 
-    AsmGenerator::Instruction::genOperation(
+    assembly::genOperation(
         ctx.asmCode, 
         "xor", "%rdx", "%rdx"
     );
-    AsmGenerator::Instruction::genMov(
+    assembly::genMov(
         ctx.asmCode, 
         operands.rightOperand, "%rax", "q"
     );
 
     if(binaryExpr->getType() == Type::INT){
-        AsmGenerator::Instruction::genOperation(
+        assembly::genOperation(
             ctx.asmCode, 
             std::format("i{}", ir::irNodeToStr(nodeType)), 
             operands.leftOperand
         );
     }
     else{
-        AsmGenerator::Instruction::genOperation(
+        assembly::genOperation(
             ctx.asmCode, 
             ir::irNodeToStr(nodeType), 
             operands.leftOperand
         );
     }
 
-    AsmGenerator::Instruction::genMov(
+    assembly::genMov(
         ctx.asmCode, 
         "%rax", operands.rightOperand, "q"
     );
@@ -142,13 +142,13 @@ void ExpressionCodeGenerator::generateMultiplicativeExpr(const ir::IRBinaryExpr*
 void ExpressionCodeGenerator::generateShiftExpr(const ir::IRBinaryExpr* binaryExpr, BinaryOperands operands){
     ir::IRNodeType nodeType{ binaryExpr->getNodeType() };
 
-    AsmGenerator::Instruction::genMov(
+    assembly::genMov(
         ctx.asmCode, 
         operands.leftOperand, 
         "%rcx", 
         "q"
     );
-    AsmGenerator::Instruction::genOperation(
+    assembly::genOperation(
         ctx.asmCode, 
         ir::irNodeToStr(nodeType), 
         "%cl", 
@@ -157,51 +157,51 @@ void ExpressionCodeGenerator::generateShiftExpr(const ir::IRBinaryExpr* binaryEx
 }
 
 void ExpressionCodeGenerator::generateLogicalAndExpr(BinaryOperands operands){
-    AsmGenerator::Instruction::genTest(
+    assembly::genTest(
         ctx.asmCode, 
         operands.leftOperand
     );
-    AsmGenerator::Instruction::genSet(
+    assembly::genSet(
         ctx.asmCode, 
         "%al", "ne"
     );
 
-    AsmGenerator::Instruction::genTest(
+    assembly::genTest(
         ctx.asmCode, 
         operands.rightOperand
     );
-    AsmGenerator::Instruction::genSet(
+    assembly::genSet(
         ctx.asmCode, 
         "%cl", "ne"
     );
 
-    AsmGenerator::Instruction::genOperation(
+    assembly::genOperation(
         ctx.asmCode, 
         "and", "%cl", "%al"
     );
-    AsmGenerator::Instruction::genMov(
+    assembly::genMov(
         ctx.asmCode,
         "%al", operands.rightOperand, "zx"
     );
 }
 
 void ExpressionCodeGenerator::generateLogicalOrExpr(BinaryOperands operands){
-    AsmGenerator::Instruction::genMov(
+    assembly::genMov(
         ctx.asmCode, 
         operands.rightOperand, "%rax"
     );
 
-    AsmGenerator::Instruction::genOperation(
+    assembly::genOperation(
         ctx.asmCode, 
         "or", operands.leftOperand, "%rax"
     );
 
-    AsmGenerator::Instruction::genSet(
+    assembly::genSet(
         ctx.asmCode, 
         "%al", "ne"
     );
 
-    AsmGenerator::Instruction::genMov(
+    assembly::genMov(
         ctx.asmCode, 
         "%al", operands.rightOperand, "zx"
     );
@@ -212,20 +212,20 @@ void ExpressionCodeGenerator::generateRelationalExpr(
     BinaryOperands operands, 
     ExprContext exprCtx
 ){
-    AsmGenerator::Instruction::genCmp(
+    assembly::genCmp(
         ctx.asmCode, 
         operands.leftOperand, 
         operands.rightOperand
     );
 
     if(exprCtx == ExprContext::VALUE){
-        AsmGenerator::Instruction::genSetcc(
+        assembly::genSetcc(
             ctx.asmCode,  
             irNodeTypeToJumpInfo(binaryExpr->getNodeType()).setcc,
             "%al"
         );
 
-        AsmGenerator::Instruction::genMov(
+        assembly::genMov(
             ctx.asmCode, 
             "%al", operands.rightOperand, "zx"
         );
@@ -237,19 +237,19 @@ void ExpressionCodeGenerator::generateConditionExpr(
     std::string_view trueLabel, 
     std::string_view falseLabel
 ){
-    size_t labNum{ AsmGenerator::Instruction::getNextLabelNum() };
+    size_t labNum{ assembly::getNextLabelNum() };
     
     ir::IRNodeType nodeType{ expr->getNodeType() };
     if(auto jumpInfo{ irNodeTypeToJumpInfo(nodeType) }; !jumpInfo.jcc.empty()){
         generateBinaryExpr(static_cast<const ir::IRBinaryExpr*>(expr), ExprContext::BRANCH);
 
-        AsmGenerator::Instruction::genJcc(
+        assembly::genJcc(
             ctx.asmCode,
             jumpInfo.jcc,
             trueLabel
         );
 
-        AsmGenerator::Instruction::genJcc(
+        assembly::genJcc(
             ctx.asmCode,
             jumpInfo.jccInverse,
             falseLabel
@@ -266,7 +266,7 @@ void ExpressionCodeGenerator::generateConditionExpr(
 
         generateConditionExpr(binaryExpr->getLeftOperandExpr(), midLabel, falseLabel);
 
-        AsmGenerator::Instruction::genLabel(
+        assembly::genLabel(
             ctx.asmCode,
             midLabel
         );
@@ -283,7 +283,7 @@ void ExpressionCodeGenerator::generateConditionExpr(
 
         generateConditionExpr(binaryExpr->getLeftOperandExpr(), trueLabel, midLabel);
 
-        AsmGenerator::Instruction::genLabel(
+        assembly::genLabel(
             ctx.asmCode,
             midLabel
         );
@@ -295,14 +295,14 @@ void ExpressionCodeGenerator::generateConditionExpr(
     generateExpr(expr);
     std::string operand{ getUnaryOperand("%rdi") };
 
-    AsmGenerator::Instruction::genTest(ctx.asmCode, operand);
+    assembly::genTest(ctx.asmCode, operand);
 
-    AsmGenerator::Instruction::genJcc(
+    assembly::genJcc(
         ctx.asmCode, 
         "jne", trueLabel
     );
     
-    AsmGenerator::Instruction::genJcc(
+    assembly::genJcc(
         ctx.asmCode, 
         "je", falseLabel
     );
@@ -312,7 +312,7 @@ void ExpressionCodeGenerator::generateConditionExpr(
 void ExpressionCodeGenerator::generateALUExpr(const ir::IRBinaryExpr* binaryExpr, BinaryOperands operands){
     ir::IRNodeType nodeType{ binaryExpr->getNodeType() };
 
-    AsmGenerator::Instruction::genOperation(
+    assembly::genOperation(
         ctx.asmCode, 
         ir::irNodeToStr(nodeType), 
         operands.leftOperand, 
@@ -322,7 +322,7 @@ void ExpressionCodeGenerator::generateALUExpr(const ir::IRBinaryExpr* binaryExpr
 
 void ExpressionCodeGenerator::generateIdExpr(const ir::IRIdExpr* idExpr) const {
     if(ctx.gpFreeRegPos < gpRegisters.size()){
-        AsmGenerator::Instruction::genMov(
+        assembly::genMov(
             ctx.asmCode, 
             getIdExprAddress(idExpr), 
             gpRegisters.at(ctx.gpFreeRegPos), 
@@ -330,7 +330,7 @@ void ExpressionCodeGenerator::generateIdExpr(const ir::IRIdExpr* idExpr) const {
         );
     }
     else{
-        AsmGenerator::Instruction::genPush(
+        assembly::genPush(
             ctx.asmCode, 
             getIdExprAddress(idExpr)
         );
@@ -346,7 +346,7 @@ void ExpressionCodeGenerator::generateLiteralExpr(const ir::IRLiteralExpr* liter
     std::string val{ formatLiteral(literalExpr) };
 
     if(ctx.gpFreeRegPos < gpRegisters.size()){
-        AsmGenerator::Instruction::genMov(
+        assembly::genMov(
             ctx.asmCode, 
             val, 
             gpRegisters.at(ctx.gpFreeRegPos), 
@@ -354,7 +354,7 @@ void ExpressionCodeGenerator::generateLiteralExpr(const ir::IRLiteralExpr* liter
         );
     }
     else{
-        AsmGenerator::Instruction::genPush(
+        assembly::genPush(
             ctx.asmCode, 
             val
         );
@@ -374,14 +374,14 @@ void ExpressionCodeGenerator::generateFunctionCallExpr(const ir::IRFunctionCallE
     // push arguments to stack
     generateArguments(callExpr);
 
-    AsmGenerator::Instruction::genCall(ctx.asmCode, callExpr->getCallName());
+    assembly::genCall(ctx.asmCode, callExpr->getCallName());
 
     // pop arguments from stack
     clearArguments(callExpr->getArgumentCount());
 
     if(expectsReturnVal){
         if(ctx.gpFreeRegPos < gpRegisters.size()){
-            AsmGenerator::Instruction::genMov(
+            assembly::genMov(
                 ctx.asmCode, 
                 "%rax", 
                 gpRegisters.at(ctx.gpFreeRegPos), 
@@ -389,7 +389,7 @@ void ExpressionCodeGenerator::generateFunctionCallExpr(const ir::IRFunctionCallE
             );
         }
         else{
-            AsmGenerator::Instruction::genPush(ctx.asmCode, "%rax");
+            assembly::genPush(ctx.asmCode, "%rax");
         }
         ctx.takeGpReg();
     }
@@ -408,7 +408,7 @@ void ExpressionCodeGenerator::generateArguments(const ir::IRFunctionCallExpr* ca
         ctx.freeGpReg();
 
         if(ctx.gpFreeRegPos < gpRegisters.size()){ // if >= gpRegisters.size() argument is already pushed
-            AsmGenerator::Instruction::genPush(
+            assembly::genPush(
                 ctx.asmCode, 
                 gpRegisters.at(ctx.gpFreeRegPos)
             );
@@ -418,10 +418,10 @@ void ExpressionCodeGenerator::generateArguments(const ir::IRFunctionCallExpr* ca
 
 void ExpressionCodeGenerator::clearArguments(size_t argCount){
     // popping arguments of the stack
-    AsmGenerator::Instruction::genOperation(
+    assembly::genOperation(
         ctx.asmCode, 
         "add", 
-        std::format("${}", argCount * AsmGenerator::Instruction::regSize), 
+        std::format("${}", argCount * assembly::regSize), 
         "%rsp"
     );
 }
@@ -440,13 +440,13 @@ void ExpressionCodeGenerator::generateTemporaryExprs(const ir::IRTemporaryExpr* 
 
         ctx.variableMap.insert({
             tempExprs->getTemporaryNameAtN(i), 
-            std::format("-{}(%rbp)", ctx.variableNum * AsmGenerator::Instruction::regSize)
+            std::format("-{}(%rbp)", ctx.variableNum * assembly::regSize)
         });
         ++ctx.variableNum;
 
         generateExpr(tempExpr);
         ctx.freeGpReg();
-        AsmGenerator::Instruction::genMov(
+        assembly::genMov(
             ctx.asmCode, 
             gpRegisters.at(ctx.gpFreeRegPos), 
             ctx.variableMap.at(tempExprs->getTemporaryNameAtN(i)), 

--- a/code-generator/code-generator/source/function_code_generator.cpp
+++ b/code-generator/code-generator/source/function_code_generator.cpp
@@ -16,12 +16,12 @@ void FunctionCodeGenerator::generateFunction(const ir::IRFunction* function){
     ctx.functionName = function->getFunctionName();
 
     // function label
-    AsmGenerator::Instruction::genLabel(ctx.asmCode, ctx.functionName);
-    AsmGenerator::Instruction::genFuncPrologue(ctx.asmCode);
+    assembly::genLabel(ctx.asmCode, ctx.functionName);
+    assembly::genFuncPrologue(ctx.asmCode);
     
     // allocation of local variables
     if(function->getRequiredMemory() != "0"){
-        AsmGenerator::Instruction::genOperation(
+        assembly::genOperation(
             ctx.asmCode, 
             "sub", 
             std::format("${}", function->getRequiredMemory()), 
@@ -36,14 +36,14 @@ void FunctionCodeGenerator::generateFunction(const ir::IRFunction* function){
     }
 
     // function end label
-    AsmGenerator::Instruction::genLabel(
+    assembly::genLabel(
         ctx.asmCode, 
         std::format("_{}_end", ctx.functionName)
     );
     
     // free local variables 
     if(function->getRequiredMemory() != "0"){
-        AsmGenerator::Instruction::genOperation(
+        assembly::genOperation(
             ctx.asmCode, 
             "add", 
             std::format("${}", function->getRequiredMemory()), 
@@ -51,13 +51,13 @@ void FunctionCodeGenerator::generateFunction(const ir::IRFunction* function){
         );
     }
 
-    AsmGenerator::Instruction::genFuncEpilogue(ctx.asmCode);
+    assembly::genFuncEpilogue(ctx.asmCode);
 
     if(function->getFunctionName() != "main"){
-        AsmGenerator::Instruction::genRet(ctx.asmCode);
+        assembly::genRet(ctx.asmCode);
     }
     else{
-        AsmGenerator::Instruction::genExit(ctx.asmCode);
+        assembly::genExit(ctx.asmCode);
     }
 
 }
@@ -68,7 +68,7 @@ void FunctionCodeGenerator::generateParameters(const ir::IRFunction* function){
         // mapping parameter to address relative to %rbp (+n(%rbp))
         ctx.variableMap.insert({
             parameter->getParameterName(), 
-            std::format("{}(%rbp)", i * AsmGenerator::Instruction::regSize)
+            std::format("{}(%rbp)", i * assembly::regSize)
         });
         ++i;
     }

--- a/code-generator/code-generator/source/statement_code_generator.cpp
+++ b/code-generator/code-generator/source/statement_code_generator.cpp
@@ -64,14 +64,14 @@ void StatementCodeGenerator::generateVariableDeclStmt(const ir::IRVariableDeclSt
             variableDecl->getVarName(), 
             std::format(
                 "-{}(%rbp)", 
-                ctx.variableNum * AsmGenerator::Instruction::regSize
+                ctx.variableNum * assembly::regSize
             )
         }) 
     };
     if(!success){
         varPtr->second = std::format(
             "-{}(%rbp)", 
-            ctx.variableNum * AsmGenerator::Instruction::regSize
+            ctx.variableNum * assembly::regSize
         );
     }
     ++ctx.variableNum;
@@ -84,7 +84,7 @@ void StatementCodeGenerator::generateVariableDeclStmt(const ir::IRVariableDeclSt
 
         exprGenerator.generateExpr(variableDecl->getAssignExpr());
         ctx.freeGpReg();
-        AsmGenerator::Instruction::genMov(
+        assembly::genMov(
             ctx.asmCode, 
             gpRegisters.at(ctx.gpFreeRegPos), 
             ctx.variableMap.at(variableDecl->getVarName()), 
@@ -93,7 +93,7 @@ void StatementCodeGenerator::generateVariableDeclStmt(const ir::IRVariableDeclSt
     }
     else{
         // default value 
-        AsmGenerator::Instruction::genMov(
+        assembly::genMov(
             ctx.asmCode, 
             "$0", 
             ctx.variableMap.at(variableDecl->getVarName()), 
@@ -103,7 +103,7 @@ void StatementCodeGenerator::generateVariableDeclStmt(const ir::IRVariableDeclSt
 }
 
 void StatementCodeGenerator::generateIfStmt(const ir::IRIfStmt* ifStmt){
-    size_t labNum{ AsmGenerator::Instruction::getNextLabelNum() };
+    size_t labNum{ assembly::getNextLabelNum() };
     size_t size{ ifStmt->getConditionCount() };
 
     std::string jmpLabel{ "" };
@@ -122,7 +122,7 @@ void StatementCodeGenerator::generateIfStmt(const ir::IRIfStmt* ifStmt){
         auto [condition, stmt, tempExpr]{ 
             ifStmt->getIfStmtAtN(i) 
         };
-        AsmGenerator::Instruction::genLabel(
+        assembly::genLabel(
             ctx.asmCode, 
             conditionLabel(i)
         );
@@ -147,39 +147,39 @@ void StatementCodeGenerator::generateIfStmt(const ir::IRIfStmt* ifStmt){
             jmpLabel
         );
 
-        AsmGenerator::Instruction::genLabel(
+        assembly::genLabel(
             ctx.asmCode, 
             bodyStartLabel
         );
 
         generateStmt(stmt);
-        AsmGenerator::Instruction::genJmp(
+        assembly::genJmp(
             ctx.asmCode, 
             endLabel
         );
     }
 
     if(ifStmt->hasElseStmt()){
-        AsmGenerator::Instruction::genLabel(
+        assembly::genLabel(
             ctx.asmCode, 
             elseLabel
         );
         generateStmt(ifStmt->getElseStmt());
     }
-    AsmGenerator::Instruction::genLabel(
+    assembly::genLabel(
         ctx.asmCode, 
         endLabel
     );
 }
 
 void StatementCodeGenerator::generateWhileStmt(const ir::IRWhileStmt* whileStmt){
-    size_t labNum{ AsmGenerator::Instruction::getNextLabelNum() };
+    size_t labNum{ assembly::getNextLabelNum() };
 
     std::string startLabel{ std::format("_while{}", labNum) };
     std::string bodyLabel{ std::format("_while{}_body", labNum) };
     std::string endLabel{ std::format("_while{}_end", labNum) };
 
-    AsmGenerator::Instruction::genLabel(
+    assembly::genLabel(
         ctx.asmCode, 
         startLabel
     );
@@ -192,24 +192,24 @@ void StatementCodeGenerator::generateWhileStmt(const ir::IRWhileStmt* whileStmt)
         endLabel
     );
 
-    AsmGenerator::Instruction::genLabel(
+    assembly::genLabel(
         ctx.asmCode, 
         bodyLabel
     );
     generateStmt(whileStmt->getStmt());
-    AsmGenerator::Instruction::genJmp(
+    assembly::genJmp(
         ctx.asmCode, 
         startLabel
     );
 
-    AsmGenerator::Instruction::genLabel(
+    assembly::genLabel(
         ctx.asmCode, 
         endLabel
     );
 }
 
 void StatementCodeGenerator::generateForStmt(const ir::IRForStmt* forStmt){
-    size_t labNum{ AsmGenerator::Instruction::getNextLabelNum() };
+    size_t labNum{ assembly::getNextLabelNum() };
 
     std::string startLabel{ std::format("_for{}", labNum) };
     std::string bodyLabel{ std::format("_for{}_body", labNum) };
@@ -219,7 +219,7 @@ void StatementCodeGenerator::generateForStmt(const ir::IRForStmt* forStmt){
     if(forStmt->hasInitializerStmt()){
         generateAssignStmt(forStmt->getInitializerStmt());
     }
-    AsmGenerator::Instruction::genLabel(
+    assembly::genLabel(
         ctx.asmCode, 
         startLabel
     );
@@ -236,7 +236,7 @@ void StatementCodeGenerator::generateForStmt(const ir::IRForStmt* forStmt){
             endLabel
         );
 
-        AsmGenerator::Instruction::genLabel(
+        assembly::genLabel(
             ctx.asmCode, 
             bodyLabel
         );
@@ -248,24 +248,24 @@ void StatementCodeGenerator::generateForStmt(const ir::IRForStmt* forStmt){
     if(forStmt->hasIncrementerStmt()){
         generateAssignStmt(forStmt->getIncrementerStmt());
     }
-    AsmGenerator::Instruction::genJmp(
+    assembly::genJmp(
         ctx.asmCode, 
         startLabel
     );
 
-    AsmGenerator::Instruction::genLabel(
+    assembly::genLabel(
         ctx.asmCode, 
         endLabel
     );
 }
 
 void StatementCodeGenerator::generateDoWhileStmt(const ir::IRDoWhileStmt* dowhileStmt){
-    size_t labNum{ AsmGenerator::Instruction::getNextLabelNum() };
+    size_t labNum{ assembly::getNextLabelNum() };
     
     std::string startLabel{ std::format("_do_while{}", labNum) };
     std::string endLabel{ std::format("_do_while{}_end", labNum) };
 
-    AsmGenerator::Instruction::genLabel(
+    assembly::genLabel(
         ctx.asmCode, 
         startLabel
     );
@@ -281,7 +281,7 @@ void StatementCodeGenerator::generateDoWhileStmt(const ir::IRDoWhileStmt* dowhil
         endLabel
     );
 
-    AsmGenerator::Instruction::genLabel(
+    assembly::genLabel(
         ctx.asmCode, 
         endLabel
     );
@@ -302,7 +302,7 @@ void StatementCodeGenerator::generateAssignStmt(const ir::IRAssignStmt* assignSt
 
     exprGenerator.generateExpr(assignStmt->getAssignedExpr());
     ctx.freeGpReg();
-    AsmGenerator::Instruction::genMov(
+    assembly::genMov(
         ctx.asmCode, 
         gpRegisters.at(ctx.gpFreeRegPos), 
         exprGenerator.getIdExprAddress(assignStmt->getVariableIdExpr()), 
@@ -320,7 +320,7 @@ void StatementCodeGenerator::generateReturnStmt(const ir::IRReturnStmt* returnSt
 
         exprGenerator.generateExpr(returnStmt->getReturnExpr());
         ctx.freeGpReg();
-        AsmGenerator::Instruction::genMov(
+        assembly::genMov(
             ctx.asmCode, 
             gpRegisters.at(ctx.gpFreeRegPos), 
             "%rax", 
@@ -328,12 +328,12 @@ void StatementCodeGenerator::generateReturnStmt(const ir::IRReturnStmt* returnSt
         );
     } 
     else{
-        AsmGenerator::Instruction::genOperation(
+        assembly::genOperation(
             ctx.asmCode, 
             "xor", "%rax", "%rax"
         );
     }
-    AsmGenerator::Instruction::genJmp(
+    assembly::genJmp(
         ctx.asmCode, 
         std::format("_{}_end", ctx.functionName)
     );
@@ -344,7 +344,7 @@ void StatementCodeGenerator::generateFunctionCallStmt(const ir::IRFunctionCallSt
 }
 
 void StatementCodeGenerator::generateSwitchStmt(const ir::IRSwitchStmt* switchStmt){
-    size_t labNum{ AsmGenerator::Instruction::getNextLabelNum() };
+    size_t labNum{ assembly::getNextLabelNum() };
 
     std::string startLabel{ std::format("_switch{}", labNum) };
     std::string defaultLabel{ std::format("_switch{}_default", labNum) };
@@ -354,7 +354,7 @@ void StatementCodeGenerator::generateSwitchStmt(const ir::IRSwitchStmt* switchSt
         return std::format("_switch{}_case{}", labNum, i);
     };
 
-    AsmGenerator::Instruction::genLabel(
+    assembly::genLabel(
         ctx.asmCode, 
         startLabel
     );
@@ -366,23 +366,23 @@ void StatementCodeGenerator::generateSwitchStmt(const ir::IRSwitchStmt* switchSt
     for(size_t i{0}; i < size; i++){
         const ir::IRCaseStmt* caseStmt{ switchStmt->getCaseStmtAtN(i) };
 
-        AsmGenerator::Instruction::genLabel(
+        assembly::genLabel(
             ctx.asmCode, 
             caseLabel(i)
         );
-        AsmGenerator::Instruction::genMov(
+        assembly::genMov(
             ctx.asmCode, 
             ctx.variableMap.at(var), 
             "%rcx", 
             "q"
         );
-        AsmGenerator::Instruction::genMov(
+        assembly::genMov(
             ctx.asmCode, 
             exprGenerator.formatLiteral(caseStmt->getLiteralExpr()), 
             "%rdx", 
             "q"
         );
-        AsmGenerator::Instruction::genCmp(ctx.asmCode, "%rcx", "%rdx");
+        assembly::genCmp(ctx.asmCode, "%rcx", "%rdx");
         
         std::string jmpLabel{""};
         if(i < size - 1){
@@ -394,7 +394,7 @@ void StatementCodeGenerator::generateSwitchStmt(const ir::IRSwitchStmt* switchSt
         else{
             jmpLabel = endLabel;
         }
-        AsmGenerator::Instruction::genJcc(
+        assembly::genJcc(
             ctx.asmCode, 
             "jne", jmpLabel
         );
@@ -404,14 +404,14 @@ void StatementCodeGenerator::generateSwitchStmt(const ir::IRSwitchStmt* switchSt
         }
 
         if(caseStmt->hasBreakStmt()){
-            AsmGenerator::Instruction::genJmp(
+            assembly::genJmp(
                 ctx.asmCode, 
                 endLabel
             );
         }
     }
     if(switchStmt->hasDefaultStmt()){
-        AsmGenerator::Instruction::genLabel(
+        assembly::genLabel(
             ctx.asmCode, 
             defaultLabel
         );
@@ -420,7 +420,7 @@ void StatementCodeGenerator::generateSwitchStmt(const ir::IRSwitchStmt* switchSt
             generateStmt(stmt.get());
         }
     }
-    AsmGenerator::Instruction::genLabel(
+    assembly::genLabel(
         ctx.asmCode, 
         endLabel
     );

--- a/common/intermediate-representation-tree/source/ir_program.cpp
+++ b/common/intermediate-representation-tree/source/ir_program.cpp
@@ -29,7 +29,7 @@ size_t ir::IRProgram::getFunctionCount() const noexcept {
 }
 
 void ir::IRProgram::addLinkedLib(const std::string& libName) {
-    linkedLibs.insert(Preprocessing::Libs::generateLibObjPath(libName));
+    linkedLibs.insert(preprocessing::generateLibObjPath(libName));
 }
 
 std::vector<std::string> ir::IRProgram::getLinkedLibs() const noexcept {

--- a/common/preprocessing/preprocessing_libs.hpp
+++ b/common/preprocessing/preprocessing_libs.hpp
@@ -4,10 +4,10 @@
 #include <string_view>
 
 /**
- * @namespace Preprocessing::Libs
+ * @namespace preprocessing
  * @brief Module containing the definitions of included libraries
 */
-namespace Preprocessing::Libs {
+namespace preprocessing {
     /// relative path to standard library
     inline constexpr std::string_view relativeLibPath{ "./libmcpp/" };
 

--- a/common/preprocessing/source/preprocessing_libs.cpp
+++ b/common/preprocessing/source/preprocessing_libs.cpp
@@ -1,10 +1,10 @@
 #include "../preprocessing_libs.hpp"
 #include <format>
 
-std::string Preprocessing::Libs::generateLibSourcePath(std::string_view libName) {
+std::string preprocessing::generateLibSourcePath(std::string_view libName) {
     return std::format("{}{}/{}{}", relativeLibPath, libName, libName, mcppExt);
 }
 
-std::string Preprocessing::Libs::generateLibObjPath(std::string_view libName) {
+std::string preprocessing::generateLibObjPath(std::string_view libName) {
     return std::format("{}{}/{}{}", relativeLibPath, libName, libName, objExt);
 }

--- a/compiler/compiler.cpp
+++ b/compiler/compiler.cpp
@@ -24,8 +24,8 @@ extern "C" {
     extern char** environ;
 }
 
-Compiler::CompileOptions Compiler::parseOptions(int argc, char** argv){
-    Compiler::CompileOptions options;
+compiler::CompileOptions compiler::parseOptions(int argc, char** argv){
+    compiler::CompileOptions options;
     for(int i{1}; i < argc; ++i){
         std::string arg{ argv[i] };
 
@@ -66,7 +66,7 @@ Compiler::CompileOptions Compiler::parseOptions(int argc, char** argv){
     return options;
 }
 
-std::string Compiler::readSourceCode(const std::string& input){
+std::string compiler::readSourceCode(const std::string& input){
     std::ifstream inputStream{ input };
 
     if(!inputStream.is_open()){
@@ -80,7 +80,7 @@ std::string Compiler::readSourceCode(const std::string& input){
     return sourceCode.str();
 }
 
-const Compiler::PreprocessResult Compiler::preprocess(const std::string& source) {
+const compiler::PreprocessResult compiler::preprocess(const std::string& source) {
     Preprocessor preprocessor;
     preprocessor.preprocess(source);
 
@@ -91,25 +91,25 @@ const Compiler::PreprocessResult Compiler::preprocess(const std::string& source)
     
     return {
         .exitCode = isInvalid 
-            ? Compiler::ExitCode::PREPROCESS_ERR 
-            : Compiler::ExitCode::NO_ERR,
+            ? compiler::ExitCode::PREPROCESS_ERR 
+            : compiler::ExitCode::NO_ERR,
         .source = preprocessor.getPreprocessed()
     };
 }
 
-Compiler::ExitCode Compiler::lexicalAnalysis(Lexer& lexer){
+compiler::ExitCode compiler::lexicalAnalysis(Lexer& lexer){
     lexer.tokenize();
     
     if(lexer.hasErrors()){
         std::cerr << lexer.getErrors();
-        return Compiler::ExitCode::LEXICAL_ERR;
+        return compiler::ExitCode::LEXICAL_ERR;
     }
 
-    return Compiler::ExitCode::NO_ERR;
+    return compiler::ExitCode::NO_ERR;
 }
 
-Compiler::ExitCode 
-Compiler::syntaxAnalysis(Lexer& lexer, std::unique_ptr<syntax::ast::ASTProgram>& astProgram){
+compiler::ExitCode 
+compiler::syntaxAnalysis(Lexer& lexer, std::unique_ptr<syntax::ast::ASTProgram>& astProgram){
     try{
         assert(lexer.completedTokenization());
         TokenConsumer tokenConsumer{ lexer };
@@ -121,10 +121,10 @@ Compiler::syntaxAnalysis(Lexer& lexer, std::unique_ptr<syntax::ast::ASTProgram>&
         return ExitCode::SYNTAX_ERR;
     }
 
-    return Compiler::ExitCode::NO_ERR;
+    return compiler::ExitCode::NO_ERR;
 }
 
-Compiler::ExitCode Compiler::semanticAnalysis(
+compiler::ExitCode compiler::semanticAnalysis(
     std::unique_ptr<syntax::ast::ASTProgram>& astProgram, 
     ThreadPool& threadPool
 ){
@@ -135,29 +135,29 @@ Compiler::ExitCode Compiler::semanticAnalysis(
 
     if(analyzer.hasSemanticErrors(astProgram.get())){
         std::cerr << analyzer.getSemanticErrors(astProgram.get());
-        return Compiler::ExitCode::SEMANTIC_ERR;
+        return compiler::ExitCode::SEMANTIC_ERR;
     }
 
-    return Compiler::ExitCode::NO_ERR;
+    return compiler::ExitCode::NO_ERR;
 }
 
-Compiler::ExitCode Compiler::transformASTToIRT(
+compiler::ExitCode compiler::transformASTToIRT(
     std::unique_ptr<syntax::ast::ASTProgram>& astProgram, 
     std::unique_ptr<ir::IRProgram>& irProgram, 
     ThreadPool& threadPool
 ){
-        IR::IntermediateRepresentation intermediateRepresentation{threadPool};
+        ir::IntermediateRepresentation intermediateRepresentation{threadPool};
         irProgram = intermediateRepresentation.transformProgram(astProgram.get());
 
         if(intermediateRepresentation.hasErrors(irProgram.get())){
             std::cerr << intermediateRepresentation.getErrors(irProgram.get());
-            return Compiler::ExitCode::IR_ERR;
+            return compiler::ExitCode::IR_ERR;
         }
 
-        return Compiler::ExitCode::NO_ERR;
+        return compiler::ExitCode::NO_ERR;
 }
 
-Compiler::ExitCode Compiler::generateProgram(
+compiler::ExitCode compiler::generateProgram(
     const ir::IRProgram* irProgram, 
     std::string_view output, 
     ThreadPool& threadPool
@@ -168,18 +168,18 @@ Compiler::ExitCode Compiler::generateProgram(
         codeGenerator.generateProgram(irProgram);
         if(!codeGenerator.successful()){
             std::cerr << std::format("Unable to open '{}'", outputFilePath);
-            return Compiler::ExitCode::CODEGEN_ERR;
+            return compiler::ExitCode::CODEGEN_ERR;
         }
     }
     catch(std::exception& e){
         std::cerr << std::format("\nCode Generation: failed\n{}\n", e.what());
-        return Compiler::ExitCode::CODEGEN_ERR;
+        return compiler::ExitCode::CODEGEN_ERR;
     }
 
-    return Compiler::ExitCode::NO_ERR;
+    return compiler::ExitCode::NO_ERR;
 }
 
-Compiler::ExitCode Compiler::assembleAndLink(
+compiler::ExitCode compiler::assembleAndLink(
     const ir::IRProgram* irProgram, 
     std::string_view output
 ){
@@ -202,42 +202,42 @@ Compiler::ExitCode Compiler::assembleAndLink(
     pid_t pid;
     if(posix_spawnp(&pid, "clang", nullptr, nullptr, argv.data(), environ) != 0){
         std::cerr << "Error: Failed to spawn clang process\n";
-        return Compiler::ExitCode::ASM_LINK_ERR;
+        return compiler::ExitCode::ASM_LINK_ERR;
     }
 
     int status;
     if (waitpid(pid, &status, 0) == -1) {
         std::cerr << "Error: waitpid failed: " << strerror(errno) << "\n";
-        return Compiler::ExitCode::ASM_LINK_ERR;
+        return compiler::ExitCode::ASM_LINK_ERR;
     }
 
     if (WIFEXITED(status) && WEXITSTATUS(status) != 0) {
         std::cerr << "Error: Clang returned non-zero exit code\n";
-        return Compiler::ExitCode::ASM_LINK_ERR;
+        return compiler::ExitCode::ASM_LINK_ERR;
     }
 
-    return Compiler::ExitCode::NO_ERR;
+    return compiler::ExitCode::NO_ERR;
 }
 
-Compiler::ExitCode Compiler::compile(Compiler::CompileOptions options) {
+compiler::ExitCode compiler::compile(compiler::CompileOptions options) {
     std::string source{ readSourceCode(options.input) };
 
-    Compiler::PreprocessResult preprocessResult{ preprocess(source) };
-    if(preprocessResult.exitCode != Compiler::ExitCode::NO_ERR){
+    compiler::PreprocessResult preprocessResult{ preprocess(source) };
+    if(preprocessResult.exitCode != compiler::ExitCode::NO_ERR){
         return preprocessResult.exitCode;
     }
 
-    Compiler::ExitCode result;
+    compiler::ExitCode result;
 
     Lexer lexer{ preprocessResult.source };
     result = lexicalAnalysis(lexer);
-    if(result != Compiler::ExitCode::NO_ERR){
+    if(result != compiler::ExitCode::NO_ERR){
         return result;
     }
     
     std::unique_ptr<syntax::ast::ASTProgram> astProgram;
     result = syntaxAnalysis(lexer, astProgram);
-    if(result != Compiler::ExitCode::NO_ERR){
+    if(result != compiler::ExitCode::NO_ERR){
         return result;
     }
 
@@ -248,13 +248,13 @@ Compiler::ExitCode Compiler::compile(Compiler::CompileOptions options) {
     ThreadPool threadPool{ std::thread::hardware_concurrency() };
 
     result = semanticAnalysis(astProgram, threadPool);
-    if(result != Compiler::ExitCode::NO_ERR){
+    if(result != compiler::ExitCode::NO_ERR){
         return result;
     }
 
     std::unique_ptr<ir::IRProgram> irProgram;
     result = transformASTToIRT(astProgram, irProgram, threadPool);
-    if(result != Compiler::ExitCode::NO_ERR){
+    if(result != compiler::ExitCode::NO_ERR){
         return result;
     }
 
@@ -263,7 +263,7 @@ Compiler::ExitCode Compiler::compile(Compiler::CompileOptions options) {
     }
 
     result = generateProgram(irProgram.get(), options.output, threadPool);
-    if(result != Compiler::ExitCode::NO_ERR){
+    if(result != compiler::ExitCode::NO_ERR){
         return result;
     }
     
@@ -274,12 +274,12 @@ Compiler::ExitCode Compiler::compile(Compiler::CompileOptions options) {
     return result;
 }
 
-void Compiler::dumpAST(syntax::ast::ASTProgram* program, std::ostream& out){
+void compiler::dumpAST(syntax::ast::ASTProgram* program, std::ostream& out){
     syntax::ast::ASTDumper dump{out};
     program->accept(dump);
 }
 
-void Compiler::dumpIR(ir::IRProgram* program, std::ostream& out){
+void compiler::dumpIR(ir::IRProgram* program, std::ostream& out){
     ir::IRDumper dump{out};
     program->accept(dump);
 }

--- a/compiler/compiler.hpp
+++ b/compiler/compiler.hpp
@@ -14,10 +14,10 @@
 #include "../thread-pool/thread_pool.hpp"
 
 /** 
- * @namespace Compiler
+ * @namespace compiler
  * @brief Module that orchestrates the process of compiling source code
 */
-namespace Compiler {
+namespace compiler {
     /** 
      * @enum ExitCode
      * @brief exit codes of the compiler

--- a/intermediate-representation/directive_intermediate_representation.hpp
+++ b/intermediate-representation/directive_intermediate_representation.hpp
@@ -5,7 +5,7 @@
 #include "../common/abstract-syntax-tree/ast_include_dir.hpp"
 #include "../common/intermediate-representation-tree/ir_program.hpp"
 
-namespace IR {
+namespace ir {
     /**
      * @class DirectiveIntermediateRepresentation
      * @brief turns ast directives into irt directives

--- a/intermediate-representation/expression_intermediate_representation.hpp
+++ b/intermediate-representation/expression_intermediate_representation.hpp
@@ -15,7 +15,7 @@
 #include "../common/intermediate-representation-tree/ir_function_call_expr.hpp"
 #include "ctx/ir_ctx.hpp"
 
-namespace IR {
+namespace ir {
     /**
      * @class ExpressionIntermediateRepresentation
      * @brief turns ast expression into irt expression

--- a/intermediate-representation/function_intermediate_representation.hpp
+++ b/intermediate-representation/function_intermediate_representation.hpp
@@ -8,7 +8,7 @@
 #include "ctx/ir_ctx.hpp"
 #include "statement_intermediate_representation.hpp"
 
-namespace IR {
+namespace ir {
     /**
      * @class FunctionIntermediateRepresentation
      * @brief turns ast function into irt function

--- a/intermediate-representation/intermediate_representation.hpp
+++ b/intermediate-representation/intermediate_representation.hpp
@@ -11,10 +11,10 @@
 #include "../thread-pool/thread_pool.hpp"
 
 /**
- * @namespace IR
+ * @namespace ir
  * @brief module defining the elements related to the intermediate representation
 */
-namespace IR {
+namespace ir {
     /**
      * @class IntermediateRepresentation
      * @brief turns abstract syntax tree into intermediate representation tree

--- a/intermediate-representation/source/directive_intermediate_representation.cpp
+++ b/intermediate-representation/source/directive_intermediate_representation.cpp
@@ -2,7 +2,7 @@
 
 #include <utility>
 
-void IR::DirectiveIntermediateRepresentation::transformDir(
+void ir::DirectiveIntermediateRepresentation::transformDir(
     ir::IRProgram* irProgram, 
     const syntax::ast::ASTProgram* astProgram
 ){
@@ -17,7 +17,7 @@ void IR::DirectiveIntermediateRepresentation::transformDir(
     }
 }
 
-void IR::DirectiveIntermediateRepresentation::transformIncludeDir(
+void ir::DirectiveIntermediateRepresentation::transformIncludeDir(
     ir::IRProgram* irProgram, 
     const syntax::ast::ASTIncludeDir* astLib
 ){

--- a/intermediate-representation/source/expression_intermediate_representation.cpp
+++ b/intermediate-representation/source/expression_intermediate_representation.cpp
@@ -5,12 +5,12 @@
 #include "../../optimization/constant_folding.hpp"
 #include "../../common/intermediate-representation-tree/ir_binary_expr.hpp"
 
-IR::ExpressionIntermediateRepresentation::ExpressionIntermediateRepresentation(
+ir::ExpressionIntermediateRepresentation::ExpressionIntermediateRepresentation(
     ir::IRFunctionContext& context
 ) : ctx{ context } {};
 
 std::unique_ptr<ir::IRExpr> 
-IR::ExpressionIntermediateRepresentation::transformExpr(const syntax::ast::ASTExpr* astExpr){
+ir::ExpressionIntermediateRepresentation::transformExpr(const syntax::ast::ASTExpr* astExpr){
     auto nodeType{ astExpr->getNodeType() };
     switch(nodeType){
         case syntax::ast::ASTNodeType::ID_EXPR:
@@ -28,7 +28,7 @@ IR::ExpressionIntermediateRepresentation::transformExpr(const syntax::ast::ASTEx
 }
 
 std::unique_ptr<ir::IRExpr> 
-IR::ExpressionIntermediateRepresentation::transformBinaryExpr(const syntax::ast::ASTBinaryExpr* astBinaryExpr){
+ir::ExpressionIntermediateRepresentation::transformBinaryExpr(const syntax::ast::ASTBinaryExpr* astBinaryExpr){
     std::unique_ptr<ir::IRExpr> leftOperand{ 
         transformExpr(astBinaryExpr->getLeftOperandExpr()) 
     };
@@ -86,7 +86,7 @@ IR::ExpressionIntermediateRepresentation::transformBinaryExpr(const syntax::ast:
 }
 
 std::unique_ptr<ir::IRIdExpr> 
-IR::ExpressionIntermediateRepresentation::transformIdExpr(
+ir::ExpressionIntermediateRepresentation::transformIdExpr(
     const syntax::ast::ASTIdExpr* astIdExpr
 ) const {
     return std::make_unique<ir::IRIdExpr>(
@@ -96,7 +96,7 @@ IR::ExpressionIntermediateRepresentation::transformIdExpr(
 }
 
 std::unique_ptr<ir::IRLiteralExpr> 
-IR::ExpressionIntermediateRepresentation::transformLiteralExpr(
+ir::ExpressionIntermediateRepresentation::transformLiteralExpr(
     const syntax::ast::ASTLiteralExpr* astLiteralExpr
 ) const {
     return std::make_unique<ir::IRLiteralExpr>(
@@ -106,7 +106,7 @@ IR::ExpressionIntermediateRepresentation::transformLiteralExpr(
 }
 
 std::unique_ptr<ir::IRFunctionCallExpr> 
-IR::ExpressionIntermediateRepresentation::transformFunctionCallExpr(
+ir::ExpressionIntermediateRepresentation::transformFunctionCallExpr(
     const syntax::ast::ASTFunctionCallExpr* astCallExpr
 ){
     std::unique_ptr<ir::IRFunctionCallExpr> irCallExpr{ 
@@ -119,7 +119,7 @@ IR::ExpressionIntermediateRepresentation::transformFunctionCallExpr(
     return irCallExpr;
 }
 
-void IR::ExpressionIntermediateRepresentation::transformArguments(
+void ir::ExpressionIntermediateRepresentation::transformArguments(
     ir::IRFunctionCallExpr* irCallExpr, 
     const syntax::ast::ASTFunctionCallExpr* astCallExpr
 ){
@@ -133,7 +133,7 @@ void IR::ExpressionIntermediateRepresentation::transformArguments(
 }
 
 // counting the number of function calls that should be replaced by temporary variables
-size_t IR::ExpressionIntermediateRepresentation::countTemporaries(const syntax::ast::ASTExpr* astExpr) const {
+size_t ir::ExpressionIntermediateRepresentation::countTemporaries(const syntax::ast::ASTExpr* astExpr) const {
     auto nodeType{ astExpr->getNodeType() };
     switch(nodeType){
         case syntax::ast::ASTNodeType::FUNCTION_CALL_EXPR:
@@ -152,14 +152,14 @@ size_t IR::ExpressionIntermediateRepresentation::countTemporaries(const syntax::
 }
 
 // generating temporary variables
-std::string IR::ExpressionIntermediateRepresentation::generateTemporaries(){
+std::string ir::ExpressionIntermediateRepresentation::generateTemporaries(){
     std::string name{ std::format("_t{}", ++ctx.temporaries) };
     ctx.temporaryNames.push(name);
     return name;
 }
 
 // assigning a returned value to temporary variables
-void IR::ExpressionIntermediateRepresentation::assignTemporaries(
+void ir::ExpressionIntermediateRepresentation::assignTemporaries(
     ir::IRTemporaryExpr* temporaryRoot, 
     const syntax::ast::ASTExpr* astExpr, 
     size_t& idx
@@ -191,7 +191,7 @@ void IR::ExpressionIntermediateRepresentation::assignTemporaries(
 
 // replacing function calls with temporary variables in expression
 std::unique_ptr<ir::IRIdExpr> 
-IR::ExpressionIntermediateRepresentation::replaceFunctionCallExpr(
+ir::ExpressionIntermediateRepresentation::replaceFunctionCallExpr(
     const syntax::ast::ASTFunctionCallExpr* astCallExpr
 ){
     assert(!ctx.temporaryNames.empty());
@@ -201,7 +201,7 @@ IR::ExpressionIntermediateRepresentation::replaceFunctionCallExpr(
 }
 
 std::unique_ptr<ir::IRTemporaryExpr> 
-IR::ExpressionIntermediateRepresentation::initiateTemporaries(
+ir::ExpressionIntermediateRepresentation::initiateTemporaries(
     const syntax::ast::ASTExpr* astExpr
 ){
     size_t tmpCount{ countTemporaries(astExpr) };

--- a/intermediate-representation/source/function_intermediate_representation.cpp
+++ b/intermediate-representation/source/function_intermediate_representation.cpp
@@ -1,10 +1,10 @@
 #include "../function_intermediate_representation.hpp"
 
-IR::FunctionIntermediateRepresentation::FunctionIntermediateRepresentation()
+ir::FunctionIntermediateRepresentation::FunctionIntermediateRepresentation()
     : stmtIR{ ctx } {}
 
 std::unique_ptr<ir::IRFunction> 
-IR::FunctionIntermediateRepresentation::transformFunction(const syntax::ast::ASTFunction* astFunction){
+ir::FunctionIntermediateRepresentation::transformFunction(const syntax::ast::ASTFunction* astFunction){
     std::unique_ptr<ir::IRFunction> irFunction{ 
         std::make_unique<ir::IRFunction>(
             astFunction->getToken().value, 
@@ -23,7 +23,7 @@ IR::FunctionIntermediateRepresentation::transformFunction(const syntax::ast::AST
     return irFunction;
 }
 
-void IR::FunctionIntermediateRepresentation::transformParameters(
+void ir::FunctionIntermediateRepresentation::transformParameters(
     ir::IRFunction* irFunction, 
     const syntax::ast::ASTFunction* astFunction
 ){
@@ -37,7 +37,7 @@ void IR::FunctionIntermediateRepresentation::transformParameters(
     }
 }
 
-void IR::FunctionIntermediateRepresentation::transformBody(
+void ir::FunctionIntermediateRepresentation::transformBody(
     ir::IRFunction* irFunction, 
     const syntax::ast::ASTFunction* astFunction
 ){
@@ -52,6 +52,6 @@ void IR::FunctionIntermediateRepresentation::transformBody(
 }
 
 const ir::IRFunctionContext& 
-IR::FunctionIntermediateRepresentation::getContext() const noexcept {
+ir::FunctionIntermediateRepresentation::getContext() const noexcept {
     return ctx;
 }

--- a/intermediate-representation/source/intermediate_representation.cpp
+++ b/intermediate-representation/source/intermediate_representation.cpp
@@ -13,11 +13,11 @@
 #include "../directive_intermediate_representation.hpp"
 #include "../function_intermediate_representation.hpp"
 
-IR::IntermediateRepresentation::IntermediateRepresentation(ThreadPool& threadPool) 
+ir::IntermediateRepresentation::IntermediateRepresentation(ThreadPool& threadPool) 
     : threadPool{ threadPool } {}
 
 std::unique_ptr<ir::IRProgram> 
-IR::IntermediateRepresentation::transformProgram(const syntax::ast::ASTProgram* program){
+ir::IntermediateRepresentation::transformProgram(const syntax::ast::ASTProgram* program){
     std::unique_ptr<ir::IRProgram> irProgram{ 
         std::make_unique<ir::IRProgram>() 
     };
@@ -78,7 +78,7 @@ IR::IntermediateRepresentation::transformProgram(const syntax::ast::ASTProgram* 
     return irProgram;
 }
 
-bool IR::IntermediateRepresentation::hasErrors(const ir::IRProgram* program) const noexcept {
+bool ir::IntermediateRepresentation::hasErrors(const ir::IRProgram* program) const noexcept {
     for(const auto& function : program->getFunctions()){
         if(!exceptions.at(function->getFunctionName()).empty()){
             return true;
@@ -87,7 +87,7 @@ bool IR::IntermediateRepresentation::hasErrors(const ir::IRProgram* program) con
     return false;
 }
 
-std::string IR::IntermediateRepresentation::getErrors(const ir::IRProgram* program) const noexcept {
+std::string ir::IntermediateRepresentation::getErrors(const ir::IRProgram* program) const noexcept {
     if(exceptions.empty()){
         return "";
     }

--- a/intermediate-representation/source/statement_intermediate_representation.cpp
+++ b/intermediate-representation/source/statement_intermediate_representation.cpp
@@ -3,12 +3,12 @@
 #include <cassert>
 #include <utility>
 
-IR::StatementIntermediateRepresentation::StatementIntermediateRepresentation(
+ir::StatementIntermediateRepresentation::StatementIntermediateRepresentation(
     ir::IRFunctionContext& context
 ) : exprIR{ context } {}
 
 std::unique_ptr<ir::IRStmt> 
-IR::StatementIntermediateRepresentation::transformStmt(const syntax::ast::ASTStmt* astStmt){
+ir::StatementIntermediateRepresentation::transformStmt(const syntax::ast::ASTStmt* astStmt){
     switch(astStmt->getNodeType()){
         case syntax::ast::ASTNodeType::VARIABLE_DECL_STMT:
             return transformVariableDeclStmt(static_cast<const syntax::ast::ASTVariableDeclStmt*>(astStmt));
@@ -46,7 +46,7 @@ IR::StatementIntermediateRepresentation::transformStmt(const syntax::ast::ASTStm
 }
 
 std::unique_ptr<ir::IRVariableDeclStmt> 
-IR::StatementIntermediateRepresentation::transformVariableDeclStmt(
+ir::StatementIntermediateRepresentation::transformVariableDeclStmt(
     const syntax::ast::ASTVariableDeclStmt* astVariableDecl
 ){
     std::unique_ptr<ir::IRVariableDeclStmt> irVariableDecl{ 
@@ -67,7 +67,7 @@ IR::StatementIntermediateRepresentation::transformVariableDeclStmt(
 }
 
 std::unique_ptr<ir::IRIfStmt> 
-IR::StatementIntermediateRepresentation::transformIfStmt(const syntax::ast::ASTIfStmt* astIfStmt){
+ir::StatementIntermediateRepresentation::transformIfStmt(const syntax::ast::ASTIfStmt* astIfStmt){
     std::unique_ptr<ir::IRIfStmt> irIfStmt{ 
         std::make_unique<ir::IRIfStmt>() 
     };
@@ -94,7 +94,7 @@ IR::StatementIntermediateRepresentation::transformIfStmt(const syntax::ast::ASTI
 }
 
 std::unique_ptr<ir::IRCompoundStmt> 
-IR::StatementIntermediateRepresentation::transformCompoundStmt(
+ir::StatementIntermediateRepresentation::transformCompoundStmt(
     const syntax::ast::ASTCompoundStmt* astCompoundStmt
 ){
     std::unique_ptr<ir::IRCompoundStmt> irCompoundStmt{ 
@@ -113,7 +113,7 @@ IR::StatementIntermediateRepresentation::transformCompoundStmt(
 }
 
 std::unique_ptr<ir::IRAssignStmt> 
-IR::StatementIntermediateRepresentation::transformAssignStmt(
+ir::StatementIntermediateRepresentation::transformAssignStmt(
     const syntax::ast::ASTAssignStmt* astAssignStmt
 ){
     std::unique_ptr<ir::IRAssignStmt> irAssignStmt{ 
@@ -132,7 +132,7 @@ IR::StatementIntermediateRepresentation::transformAssignStmt(
 }
 
 std::unique_ptr<ir::IRReturnStmt> 
-IR::StatementIntermediateRepresentation::transformReturnStmt(
+ir::StatementIntermediateRepresentation::transformReturnStmt(
     const syntax::ast::ASTReturnStmt* astReturnStmt
 ){
     std::unique_ptr<ir::IRReturnStmt> irReturnStmt{ 
@@ -152,7 +152,7 @@ IR::StatementIntermediateRepresentation::transformReturnStmt(
 }
 
 std::unique_ptr<ir::IRFunctionCallStmt> 
-IR::StatementIntermediateRepresentation::transformFunctionCallStmt(
+ir::StatementIntermediateRepresentation::transformFunctionCallStmt(
     const syntax::ast::ASTFunctionCallStmt* astCallStmt
 ){
     std::unique_ptr<ir::IRFunctionCallStmt> irCallStmt{ 
@@ -169,7 +169,7 @@ IR::StatementIntermediateRepresentation::transformFunctionCallStmt(
 }
 
 std::unique_ptr<ir::IRWhileStmt> 
-IR::StatementIntermediateRepresentation::transformWhileStmt(
+ir::StatementIntermediateRepresentation::transformWhileStmt(
     const syntax::ast::ASTWhileStmt* astWhileStmt
 ){
     std::unique_ptr<ir::IRWhileStmt> irWhileStmt{ 
@@ -187,7 +187,7 @@ IR::StatementIntermediateRepresentation::transformWhileStmt(
 }
 
 std::unique_ptr<ir::IRForStmt> 
-IR::StatementIntermediateRepresentation::transformForStmt(
+ir::StatementIntermediateRepresentation::transformForStmt(
     const syntax::ast::ASTForStmt* astForStmt
 ){
     std::unique_ptr<ir::IRForStmt> irForStmt{ 
@@ -221,7 +221,7 @@ IR::StatementIntermediateRepresentation::transformForStmt(
 }
 
 std::unique_ptr<ir::IRDoWhileStmt> 
-IR::StatementIntermediateRepresentation::transformDoWhileStmt(
+ir::StatementIntermediateRepresentation::transformDoWhileStmt(
     const syntax::ast::ASTDoWhileStmt* astDowhileStmt
 ){
     std::unique_ptr<ir::IRDoWhileStmt> irDowhileStmt{ 
@@ -238,7 +238,7 @@ IR::StatementIntermediateRepresentation::transformDoWhileStmt(
 }
 
 std::unique_ptr<ir::IRSwitchStmt> 
-IR::StatementIntermediateRepresentation::transformSwitchStmt(
+ir::StatementIntermediateRepresentation::transformSwitchStmt(
     const syntax::ast::ASTSwitchStmt* astSwitchStmt
 ){
     std::unique_ptr<ir::IRSwitchStmt> irSwitchStmt{ 
@@ -267,7 +267,7 @@ IR::StatementIntermediateRepresentation::transformSwitchStmt(
 }
 
 std::unique_ptr<ir::IRCaseStmt> 
-IR::StatementIntermediateRepresentation::transformCaseStmt(
+ir::StatementIntermediateRepresentation::transformCaseStmt(
     const syntax::ast::ASTCaseStmt* astCaseStmt
 ){
     std::unique_ptr<ir::IRCaseStmt> irCaseStmt{ std::make_unique<ir::IRCaseStmt>() };
@@ -281,7 +281,7 @@ IR::StatementIntermediateRepresentation::transformCaseStmt(
 }
 
 std::unique_ptr<ir::IRDefaultStmt> 
-IR::StatementIntermediateRepresentation::transformDefaultStmt(
+ir::StatementIntermediateRepresentation::transformDefaultStmt(
     const syntax::ast::ASTDefaultStmt* astDefaultStmt
 ){
     std::unique_ptr<ir::IRDefaultStmt> irDefaultStmt{ std::make_unique<ir::IRDefaultStmt>() };
@@ -295,7 +295,7 @@ IR::StatementIntermediateRepresentation::transformDefaultStmt(
 }
 
 std::unique_ptr<ir::IRSwitchBlockStmt> 
-IR::StatementIntermediateRepresentation::transformSwitchBlockStmt(
+ir::StatementIntermediateRepresentation::transformSwitchBlockStmt(
     const syntax::ast::ASTSwitchBlockStmt* astSwitchBlockStmt
 ){
     std::unique_ptr<ir::IRSwitchBlockStmt> irSwitchBlockStmt{ 

--- a/intermediate-representation/statement_intermediate_representation.hpp
+++ b/intermediate-representation/statement_intermediate_representation.hpp
@@ -29,7 +29,7 @@
 #include "expression_intermediate_representation.hpp"
 #include "ctx/ir_ctx.hpp"
 
-namespace IR {
+namespace ir {
     /**
      * @class StatementIntermediateRepresentation
      * @brief turns ast statement into irt statement

--- a/main.cpp
+++ b/main.cpp
@@ -7,12 +7,12 @@
 
 int main(int argc, char** argv){
     try {
-        Compiler::CompileOptions options{ Compiler::parseOptions(argc, argv) };
+        compiler::CompileOptions options{ compiler::parseOptions(argc, argv) };
         auto start{ std::chrono::high_resolution_clock::now() };
 
-        Compiler::ExitCode ret{ Compiler::compile(options) };
+        compiler::ExitCode ret{ compiler::compile(options) };
 
-        if(ret != Compiler::ExitCode::NO_ERR){
+        if(ret != compiler::ExitCode::NO_ERR){
             std::cerr << "Program failed to compile!\n";
             return 1;
         }

--- a/preprocessor/preprocessor.cpp
+++ b/preprocessor/preprocessor.cpp
@@ -75,7 +75,7 @@ void Preprocessor::handleInclude(const std::string& source, size_t& idx){
     }
 
     std::string includeLib{ source.substr(start, idx - start) };
-    std::string includeLibPath{ Preprocessing::Libs::generateLibSourcePath(includeLib) };
+    std::string includeLibPath{ preprocessing::generateLibSourcePath(includeLib) };
 
     if(!includedLibraries.contains(includeLib)){
         includedLibraries.insert(includeLib);

--- a/unit-tests/code-generator-test/code_generator_fixture.hpp
+++ b/unit-tests/code-generator-test/code_generator_fixture.hpp
@@ -19,7 +19,7 @@ protected:
     void initCodeGen(std::string_view source){
         __test__writeSourceToFile(source, input);
     
-        Compiler::compile({.input = input, .output = output});
+        compiler::compile({.input = input, .output = output});
         run_status = __test__runCommand({
             std::format("./{}", output)
         });

--- a/unit-tests/compiler-test/compiler_fixture.hpp
+++ b/unit-tests/compiler-test/compiler_fixture.hpp
@@ -11,11 +11,11 @@ class CompilerFixture : public ::testing::Test {
 protected:
     const std::string input{ "tmp.mcpp" };
     const std::string output{ "tmp" };
-    Compiler::ExitCode returnCode;
+    compiler::ExitCode returnCode;
 
     void initCompiler(std::string_view source){
         __test__writeSourceToFile(source, input);
-        returnCode =  Compiler::compile({
+        returnCode =  compiler::compile({
             .stopAfterAssembly = true, 
             .input = input, 
             .output = output

--- a/unit-tests/compiler-test/compiler_test.cpp
+++ b/unit-tests/compiler-test/compiler_test.cpp
@@ -5,47 +5,47 @@
 TEST_F(CompilerFixture, NoErr){
     initCompiler("int main(){ return 0; }");
 
-    ASSERT_EQ(returnCode, Compiler::ExitCode::NO_ERR);
+    ASSERT_EQ(returnCode, compiler::ExitCode::NO_ERR);
 }
 
 TEST_F(CompilerFixture, NoErrScope){
     initCompiler("int main(){ {int a;} int a; return 0; }");
 
-    ASSERT_EQ(returnCode, Compiler::ExitCode::NO_ERR);
+    ASSERT_EQ(returnCode, compiler::ExitCode::NO_ERR);
 }
 
 TEST_F(CompilerFixture, LexicalErr){
     initCompiler("int mai$n(){ return 0; }");
 
-    ASSERT_EQ(returnCode, Compiler::ExitCode::LEXICAL_ERR);
+    ASSERT_EQ(returnCode, compiler::ExitCode::LEXICAL_ERR);
 }
 
 TEST_F(CompilerFixture, SyntaxErr){
     initCompiler("main(){ return 0; }");
 
-    ASSERT_EQ(returnCode, Compiler::ExitCode::SYNTAX_ERR);
+    ASSERT_EQ(returnCode, compiler::ExitCode::SYNTAX_ERR);
 }
 
 TEST_F(CompilerFixture, SemanticErrTypeMismatch){
     initCompiler("int main(){ return 5 + 3u; }");
 
-    ASSERT_EQ(returnCode, Compiler::ExitCode::SEMANTIC_ERR);
+    ASSERT_EQ(returnCode, compiler::ExitCode::SEMANTIC_ERR);
 }
 
 TEST_F(CompilerFixture, SemanticErrUndefVariable){
     initCompiler("int main(){ return a; }");
 
-    ASSERT_EQ(returnCode, Compiler::ExitCode::SEMANTIC_ERR);
+    ASSERT_EQ(returnCode, compiler::ExitCode::SEMANTIC_ERR);
 }
 
 TEST_F(CompilerFixture, SemanticErrRedef){
     initCompiler("int main(){ int a; int a; return 0; }");
 
-    ASSERT_EQ(returnCode, Compiler::ExitCode::SEMANTIC_ERR);
+    ASSERT_EQ(returnCode, compiler::ExitCode::SEMANTIC_ERR);
 }
 
 TEST_F(CompilerFixture, IRErr){
     initCompiler("int main(){ return 3/0; }");
 
-    ASSERT_EQ(returnCode, Compiler::ExitCode::IR_ERR);
+    ASSERT_EQ(returnCode, compiler::ExitCode::IR_ERR);
 }

--- a/unit-tests/intermediate-representation-test/intermediate_representation_test.hpp
+++ b/unit-tests/intermediate-representation-test/intermediate_representation_test.hpp
@@ -6,7 +6,7 @@
 #include "../../intermediate-representation/intermediate_representation.hpp"
 #include "../../intermediate-representation/function_intermediate_representation.hpp"
 
-class IntermediateRepresentationTest : public IR::IntermediateRepresentation {
+class IntermediateRepresentationTest : public ir::IntermediateRepresentation {
     public:
         IntermediateRepresentationTest(ThreadPool& threadPool) : IntermediateRepresentation{ threadPool } {}
 
@@ -16,20 +16,20 @@ class IntermediateRepresentationTest : public IR::IntermediateRepresentation {
         }
 };
 
-class FunctionIntermediateRepresentationTest : public IR::FunctionIntermediateRepresentation {
+class FunctionIntermediateRepresentationTest : public ir::FunctionIntermediateRepresentation {
 
 };
 
-class StatementIntermediateRepresentationTest : public IR::StatementIntermediateRepresentation {
+class StatementIntermediateRepresentationTest : public ir::StatementIntermediateRepresentation {
 public:
     StatementIntermediateRepresentationTest(ir::IRFunctionContext& ctx)
-        : IR::StatementIntermediateRepresentation{ ctx } {}
+        : ir::StatementIntermediateRepresentation{ ctx } {}
 };
 
-class ExpressionIntermediateRepresentationTest : public IR::ExpressionIntermediateRepresentation {
+class ExpressionIntermediateRepresentationTest : public ir::ExpressionIntermediateRepresentation {
 public:
     ExpressionIntermediateRepresentationTest(ir::IRFunctionContext& ctx)
-        : IR::ExpressionIntermediateRepresentation{ ctx } {}
+        : ir::ExpressionIntermediateRepresentation{ ctx } {}
 };
 
 #endif


### PR DESCRIPTION
- renamed Compiler namespace to compiler
- renamed IR namespace to ir
- renamed Preprocessing::Libs namespace to preprocessing
- renamed AsmGenerator::Instruction namespace to assembly